### PR TITLE
Validate upload filenames before size check

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -186,7 +186,11 @@ def _ensure_pdf_size(file: UploadFile, file_bytes: bytes) -> None:
     if size > MAX_PDF_SIZE_BYTES:
         raise HTTPException(status_code=400, detail="PDF exceeds 80 MB limit.")
 
-    if not file.filename.lower().endswith(".pdf"):
+    filename = file.filename
+    if not isinstance(filename, str) or not filename.strip():
+        raise HTTPException(status_code=400, detail="Filename is required.")
+
+    if not filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="Filename must end with .pdf")
 
 

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+
+def test_upload_rejects_missing_filename() -> None:
+    pdf_bytes = b"%PDF-1.4\n%%EOF"
+    boundary = "testboundary"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename=""\r\n'
+        "Content-Type: application/pdf\r\n"
+        "\r\n"
+    ).encode() + pdf_bytes + (
+        f"\r\n--{boundary}--\r\n"
+    ).encode()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/upload",
+            data=body,
+            headers={"content-type": f"multipart/form-data; boundary={boundary}"},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Filename is required."}


### PR DESCRIPTION
## Summary
- require upload filenames to be non-empty before checking the extension
- add a regression test that posts a PDF without a filename header and expects a 400 response

## Testing
- pytest backend/tests/test_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68d1b9ae75c8833292fcd59e7d14946d